### PR TITLE
[WIP] Changes to Layout

### DIFF
--- a/clia_petition/forms.py
+++ b/clia_petition/forms.py
@@ -5,8 +5,16 @@ from .models import Profile
 
 User = get_user_model()
 
+class BootstrapModelForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(BootstrapModelForm, self).__init__(*args, **kwargs)
+        for field in iter(self.fields):
+            self.fields[field].widget.attrs.update({
+                'class': 'form-control'
+            })
 
-class SignatureForm(forms.ModelForm):
+
+class SignatureForm(BootstrapModelForm):
     """
     Collect signature data.
 

--- a/clia_petition/templates/base.html
+++ b/clia_petition/templates/base.html
@@ -13,7 +13,7 @@
     <!-- Uncomment the following if a favicon is added. -->
     <!-- <link rel="icon" type="image/png" href="images/favicon.png"> -->
 
-    <title>{% block head_title %}Open Humans Data Source{% endblock head_title %}</title>
+    <title>{% block head_title %}Change CLIA{% endblock head_title %}</title>
 
     <!-- Bootstrap -->
     <!-- Compiled and minified CSS -->

--- a/clia_petition/templates/clia_petition/index.html
+++ b/clia_petition/templates/clia_petition/index.html
@@ -39,7 +39,6 @@
       </div>
       {% endif %}
 
-    </div>
     <div class="col-sm-6">
       <h3>Your details.</h3>
 
@@ -95,7 +94,11 @@
   {% if not user.is_authenticated %}
 
   <hr>
+  <div class="row">
 
+    <div class="col-sm-6">
+
+  <div class="well">
   <h2>Add your voice.</h2>
   {{ form.non_field_errors }}
   <form action="{% url 'home' %}" method="post">
@@ -115,16 +118,16 @@
       {{ form.name.help_text }}
     </p>
 
+    <p>
     {{ form.us_status.errors }}
-    <ul id="id_us_status">
+    <label for="{{id_us_status.id_for_label}}">Status:</label>
       {% for choice in form.us_status %}
-        <li>
-        {{ choice.value }}
+        <div class="radio">
         {{ choice }}
-        </li>
+        </div>
       {% endfor %}
-    </ul>
     {{ form.us_status.help_text }}
+  </p>
 
     <p>
       {{ form.comments.errors }}
@@ -134,11 +137,11 @@
     </p>
 
     <p>
-      <input type="submit" name="action" value="Sign with email" />
+      <input type="submit" name="action" class="btn btn-default" value="Sign with email" />
     </p>
 
     <p>
-      <input type="submit" name="action" value="Sign with Twitter account" />
+      <input type="submit" name="action" class="btn btn-primary" value="Sign with Twitter account" />
     </p>
 
   </form>
@@ -147,7 +150,9 @@
     Did you already sign – but want to update your information?
     <a href="{% url 'account_reset_password' %}">Request a login link.</a>
   </p>
-
+  </div>
+</div>
+</div>
   {% endif %}
 
 {% endblock content %}

--- a/clia_petition/templates/clia_petition/partials/petition_description.html
+++ b/clia_petition/templates/clia_petition/partials/petition_description.html
@@ -33,7 +33,34 @@
       interpretations that do not result in a wholesale prohibition
       on return of data.
     </p>
-    <a href="{% url 'why' %}">Read more...</a>
+
+    <!--
+<a href="{% url 'why' %}">Read more...</a>
+    //-->
+
+    <button type="button" class="btn btn-info" data-toggle="collapse" data-target="#demo">
+      Read More!
+    </button>
+
+  <div id="demo" class="collapse">
+
+    <h2>Opinions and advocacy pieces</h2>
+
+    <p>
+      Want to learn more? The opinion and advocacy pieces below explore the legal
+      issues, ethics, and harmful consequences of the current CMS policy.
+    </p>
+
+    <ul>
+      <li><a href="#">Our DNA Dystopia</a> – Madeleine Price Ball</li>
+    </ul>
+
+    <p><i>
+      Have you written something that can be listed here? Get in touch with
+      us, and we can add it to this list!
+    </i></p>
+  </div>
+
   </div>
 
 </div>


### PR DESCRIPTION
- [x] Did a `well` around the signup form (see issue #5)
- [x] The signup form now has bootstrap `form` layout and is 6 columns wide
- [x] `Read More` is now a collapsable (issue #4)
- [ ] Brokenish: The radio buttons now look strange, c.f. screenshot below. Any idea how to fix that?
- [ ] Decide: How do we want to order sign-up/new signatures/high profile signatures?

![screen shot 2017-05-22 at 17 38 38](https://cloud.githubusercontent.com/assets/674899/26316697/6b828536-3f15-11e7-86a5-2fd067892a64.png)
